### PR TITLE
cast to int

### DIFF
--- a/cleanup.py
+++ b/cleanup.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 import subprocess
 import os
 
-KEEP_LAST_VERSIONS = os.environ.get('KEEP_LAST_VERSIONS', 4)
+KEEP_LAST_VERSIONS = int(os.environ.get('KEEP_LAST_VERSIONS', 4))
 
 
 def find_obsolete_images(images):


### PR DESCRIPTION
```
docker run --rm \
>  -v /var/run/docker.sock:/var/run/docker.sock \
>  -e KEEP_LAST_VERSIONS=3 dreipol/cleanup-deis-images
Unable to find image 'dreipol/cleanup-deis-images:latest' locally
latest: Pulling from dreipol/cleanup-deis-images
fdd5d7827f33: Already exists
a3ed95caeb02: Pull complete
0f35d0fe50cc: Already exists
627b6479c8f7: Pull complete
67c44324f4e3: Pull complete
9ee7e6ec2a05: Pull complete
bbaa314a5925: Pull complete
629f63939484: Pull complete
502f3521e61a: Pull complete
417ca18f571f: Pull complete
3ebf1e39590a: Pull complete
Digest: sha256:47422c359b0d4a187877a2525a10bca58500515de72f855d25eab53087951592
Status: Downloaded newer image for dreipol/cleanup-deis-images:latest
Traceback (most recent call last):
  File "cleanup.py", line 49, in <module>
    for image_name in find_obsolete_images(images):
  File "cleanup.py", line 11, in find_obsolete_images
    if len(versions) > KEEP_LAST_VERSIONS:
TypeError: unorderable types: int() > str()
```

Casting KEEP_LAST_VERSIONS to an integer fixes the issue for me.
